### PR TITLE
Add function for coordinates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ array_to_latex.egg*
 array_to_latex.code-workspace
 borg-env
 .ipynb_checkpoints/*
+.venv

--- a/Examples.ipynb
+++ b/Examples.ipynb
@@ -279,7 +279,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you want to plot a few nods or points in latex using tizk, you may want to output a list of coordinates."
+    "If you want to plot a few nods or points in latex using tizk, like\n",
+    "```latex\n",
+    "\\documentclass{standalone}\n",
+    "\\usepackage{pgfplots}\n",
+    "\\begin{document}\n",
+    "\\begin{tikzpicture}\n",
+    "  \\foreach \\Point in \n",
+    "  {(0.23,2.46),(1.23,2.24)}\n",
+    "  {\\node at \\Point {$\\circ$};}\n",
+    "\\end{tikzpicture}\n",
+    "\\end{document}\n",
+    "```\n",
+    "you may want to output a list of coordinates."
    ]
   },
   {
@@ -296,7 +308,7 @@
     }
    ],
    "source": [
-    "A = np.array([[1.23456, 23.45678],[456.23, 8.239521]])\n",
+    "A = np.array([[0.23456, 2.45678],[1.23, 2.239521]])\n",
     "a2l.to_ltx(A, frmt='{:1.2f}', arraytype='coords')"
    ]
   },

--- a/Examples.ipynb
+++ b/Examples.ipynb
@@ -9,18 +9,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "import numpy as np\n",
@@ -40,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 2,
    "metadata": {
     "scrolled": true
    },
@@ -70,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -116,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -144,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 6,
    "metadata": {
     "scrolled": true
    },
@@ -173,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -216,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 8,
    "metadata": {
     "scrolled": false
    },
@@ -238,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 9,
    "metadata": {
     "scrolled": false
    },
@@ -260,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 10,
    "metadata": {
     "scrolled": false
    },
@@ -284,6 +275,32 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want to plot a few nods or points in latex using tizk, you may want to output a list of coordinates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{(1.23,23.46),(456.23,8.24)}\n"
+     ]
+    }
+   ],
+   "source": [
+    "A = np.array([[1.23456, 23.45678],[456.23, 8.239521]])\n",
+    "a2l.to_ltx(A, frmt='{:1.2f}', arraytype='coords')"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -292,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -300,10 +317,8 @@
      "output_type": "stream",
      "text": [
       "\\begin{bmatrix}\n",
-      "  1.23\\times 10^{+00}\\\\\n",
-      "  2.35\\times 10^{+01}\\\\\n",
-      "  4.56\\times 10^{+02}\\\\\n",
-      "  8.24\\times 10^{+00}\n",
+      "  1.23\\times 10^{+00} &  2.35\\times 10^{+01}\\\\\n",
+      "  4.56\\times 10^{+02} &  8.24\\times 10^{+00}\n",
       "\\end{bmatrix}\n"
      ]
     }
@@ -316,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -324,10 +339,8 @@
      "output_type": "stream",
      "text": [
       "\\begin{bmatrix}\n",
-      "    1.23\\\\\n",
-      "   23.46\\\\\n",
-      "  456.23\\\\\n",
-      "    8.24\n",
+      "    1.23 &   23.46\\\\\n",
+      "  456.23 &    8.24\n",
       "\\end{bmatrix}\n"
      ]
     }
@@ -350,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -360,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -394,43 +407,43 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>7</td>\n",
+       "      <td>3</td>\n",
        "      <td>9</td>\n",
-       "      <td>5</td>\n",
-       "      <td>4</td>\n",
-       "      <td>5</td>\n",
-       "      <td>6</td>\n",
+       "      <td>7</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>3</td>\n",
-       "      <td>6</td>\n",
-       "      <td>9</td>\n",
        "      <td>1</td>\n",
+       "      <td>8</td>\n",
+       "      <td>8</td>\n",
+       "      <td>9</td>\n",
+       "      <td>4</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>1</td>\n",
-       "      <td>3</td>\n",
-       "      <td>3</td>\n",
-       "      <td>7</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>1</td>\n",
-       "      <td>3</td>\n",
+       "      <td>5</td>\n",
        "      <td>9</td>\n",
-       "      <td>3</td>\n",
+       "      <td>0</td>\n",
        "      <td>6</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>9</td>\n",
+       "      <th>3</th>\n",
+       "      <td>5</td>\n",
        "      <td>4</td>\n",
-       "      <td>1</td>\n",
-       "      <td>3</td>\n",
+       "      <td>7</td>\n",
+       "      <td>7</td>\n",
+       "      <td>7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2</td>\n",
        "      <td>9</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -438,14 +451,14 @@
       ],
       "text/plain": [
        "   a  b  c  d  e\n",
-       "0  9  5  4  5  6\n",
-       "1  2  3  6  9  1\n",
-       "2  1  3  3  7  1\n",
-       "3  1  3  9  3  6\n",
-       "4  9  4  1  3  9"
+       "0  1  7  3  9  7\n",
+       "1  1  8  8  9  4\n",
+       "2  1  5  9  0  6\n",
+       "3  5  4  7  7  7\n",
+       "4  2  9  3  0  0"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -456,20 +469,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([[9, 5, 4, 5, 6],\n",
-       "       [2, 3, 6, 9, 1],\n",
-       "       [1, 3, 3, 7, 1],\n",
-       "       [1, 3, 9, 3, 6],\n",
-       "       [9, 4, 1, 3, 9]])"
+       "array([[1, 7, 3, 9, 7],\n",
+       "       [1, 8, 8, 9, 4],\n",
+       "       [1, 5, 9, 0, 6],\n",
+       "       [5, 4, 7, 7, 7],\n",
+       "       [2, 9, 3, 0, 0]])"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -480,7 +493,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 17,
    "metadata": {
     "scrolled": true
    },
@@ -490,11 +503,11 @@
      "output_type": "stream",
      "text": [
       "\\begin{bmatrix}\n",
-      " 0 &  9.00 &  5.00 &  4.00 &  5.00 &  6.00\\\\\n",
-      " 1 &  2.00 &  3.00 &  6.00 &  9.00 &  1.00\\\\\n",
-      " 2 &  1.00 &  3.00 &  3.00 &  7.00 &  1.00\\\\\n",
-      " 3 &  1.00 &  3.00 &  9.00 &  3.00 &  6.00\\\\\n",
-      " 4 &  9.00 &  4.00 &  1.00 &  3.00 &  9.00\n",
+      " 0 &  1.00 &  7.00 &  3.00 &  9.00 &  7.00\\\\\n",
+      " 1 &  1.00 &  8.00 &  8.00 &  9.00 &  4.00\\\\\n",
+      " 2 &  1.00 &  5.00 &  9.00 &  0.00 &  6.00\\\\\n",
+      " 3 &  5.00 &  4.00 &  7.00 &  7.00 &  7.00\\\\\n",
+      " 4 &  2.00 &  9.00 &  3.00 &  0.00 &  0.00\n",
       "\\end{bmatrix}\n"
      ]
     }
@@ -505,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 18,
    "metadata": {
     "scrolled": true
    },
@@ -517,11 +530,11 @@
       "\\begin{tabular}{lrrrrr}\n",
       "\\toprule\n",
       "     & a & b & c & d & e \\\\\\n\\midrule\n",
-      " 0 &  9.00 &  5.00 &  4.00 &  5.00 &  6.00\\\\\n",
-      " 1 &  2.00 &  3.00 &  6.00 &  9.00 &  1.00\\\\\n",
-      " 2 &  1.00 &  3.00 &  3.00 &  7.00 &  1.00\\\\\n",
-      " 3 &  1.00 &  3.00 &  9.00 &  3.00 &  6.00\\\\\n",
-      " 4 &  9.00 &  4.00 &  1.00 &  3.00 &  9.00\\\\\n",
+      " 0 &  1.00 &  7.00 &  3.00 &  9.00 &  7.00\\\\\n",
+      " 1 &  1.00 &  8.00 &  8.00 &  9.00 &  4.00\\\\\n",
+      " 2 &  1.00 &  5.00 &  9.00 &  0.00 &  6.00\\\\\n",
+      " 3 &  5.00 &  4.00 &  7.00 &  7.00 &  7.00\\\\\n",
+      " 4 &  2.00 &  9.00 &  3.00 &  0.00 &  0.00\\\\\n",
       "\\bottomrule\n",
       "\\end{tabular}\n"
      ]
@@ -533,7 +546,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -594,7 +607,7 @@
        "4  honey badger"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -606,7 +619,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -641,47 +654,47 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>7</td>\n",
+       "      <td>3</td>\n",
        "      <td>9</td>\n",
-       "      <td>5</td>\n",
-       "      <td>4</td>\n",
-       "      <td>5</td>\n",
-       "      <td>6</td>\n",
+       "      <td>7</td>\n",
        "      <td>cat</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>3</td>\n",
-       "      <td>6</td>\n",
-       "      <td>9</td>\n",
        "      <td>1</td>\n",
+       "      <td>8</td>\n",
+       "      <td>8</td>\n",
+       "      <td>9</td>\n",
+       "      <td>4</td>\n",
        "      <td>dog</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>1</td>\n",
-       "      <td>3</td>\n",
-       "      <td>3</td>\n",
-       "      <td>7</td>\n",
-       "      <td>1</td>\n",
+       "      <td>5</td>\n",
+       "      <td>9</td>\n",
+       "      <td>0</td>\n",
+       "      <td>6</td>\n",
        "      <td>bird</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>1</td>\n",
-       "      <td>3</td>\n",
-       "      <td>9</td>\n",
-       "      <td>3</td>\n",
-       "      <td>6</td>\n",
+       "      <td>5</td>\n",
+       "      <td>4</td>\n",
+       "      <td>7</td>\n",
+       "      <td>7</td>\n",
+       "      <td>7</td>\n",
        "      <td>snake</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
+       "      <td>2</td>\n",
        "      <td>9</td>\n",
-       "      <td>4</td>\n",
-       "      <td>1</td>\n",
        "      <td>3</td>\n",
-       "      <td>9</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
        "      <td>honey badger</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -690,14 +703,14 @@
       ],
       "text/plain": [
        "   a  b  c  d  e          pets\n",
-       "0  9  5  4  5  6           cat\n",
-       "1  2  3  6  9  1           dog\n",
-       "2  1  3  3  7  1          bird\n",
-       "3  1  3  9  3  6         snake\n",
-       "4  9  4  1  3  9  honey badger"
+       "0  1  7  3  9  7           cat\n",
+       "1  1  8  8  9  4           dog\n",
+       "2  1  5  9  0  6          bird\n",
+       "3  5  4  7  7  7         snake\n",
+       "4  2  9  3  0  0  honey badger"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -709,7 +722,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -719,11 +732,11 @@
       "\\begin{tabular}{lrrrrrr}\n",
       "\\toprule\n",
       "     & a & b & c & d & e & pets \\\\\\n\\midrule\n",
-      " 0 &  9.00 &  5.00 &  4.00 &  5.00 &  6.00 &  cat         \\\\\n",
-      " 1 &  2.00 &  3.00 &  6.00 &  9.00 &  1.00 &  dog         \\\\\n",
-      " 2 &  1.00 &  3.00 &  3.00 &  7.00 &  1.00 &  bird        \\\\\n",
-      " 3 &  1.00 &  3.00 &  9.00 &  3.00 &  6.00 &  snake       \\\\\n",
-      " 4 &  9.00 &  4.00 &  1.00 &  3.00 &  9.00 &  honey badger\\\\\n",
+      " 0 &  1.00 &  7.00 &  3.00 &  9.00 &  7.00 &  cat         \\\\\n",
+      " 1 &  1.00 &  8.00 &  8.00 &  9.00 &  4.00 &  dog         \\\\\n",
+      " 2 &  1.00 &  5.00 &  9.00 &  0.00 &  6.00 &  bird        \\\\\n",
+      " 3 &  5.00 &  4.00 &  7.00 &  7.00 &  7.00 &  snake       \\\\\n",
+      " 4 &  2.00 &  9.00 &  3.00 &  0.00 &  0.00 &  honey badger\\\\\n",
       "\\bottomrule\n",
       "\\end{tabular}\n"
      ]
@@ -735,7 +748,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -756,7 +769,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -766,7 +779,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.13 ('base')",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -780,7 +793,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.11.0"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,
@@ -844,7 +857,7 @@
   },
   "vscode": {
    "interpreter": {
-    "hash": "b61f047e492f79e7db889a054407d86715719f3f60d4e2bf89f78dea9df91e01"
+    "hash": "8264b34d39e23030c6fea90141f98fb73263e8f59eb03375f5597f19271b8965"
    }
   }
  },

--- a/array_to_latex/__init__.py
+++ b/array_to_latex/__init__.py
@@ -62,35 +62,6 @@ def to_clp(a, frmt='{:1.2f}', arraytype='bmatrix', imstring='j'):
               'means to use this function')
 
 
-def to_coords(a, frmt='{:6.2f}'):
-    r"""Retrun a list of coordinates given a numpy array.
-
-    Parameters
-    ----------
-    a         : float array
-    frmt      : string
-        python 3 formatter, optional-
-        https://mkaz.tech/python-string-format.html
-    
-    Returns
-    -------
-    out: str
-        list of coordinates in the form (x1,y1),(x2,y2),...
-    
-    Examples
-    --------
-    >>> import numpy as np
-    >>> import array_to_latex as a2l
-    >>> A = np.array([[1.23456, 23.45678],[456.23, 8.239521]])
-    >>> a2l.to_coords(A, frmt = '{:1.2f}')
-    '{(1.23,23.46),(456.23,8.24)}'
-    """
-    out = '{'
-    out += ','.join([f"({','.join([frmt.format(x) for x in r])})" for r in a])
-    out += '}'
-    return out
-
-
 def _numpyarraytolatex(a, frmt='{:6.2f}', arraytype='bmatrix', nargout=0,
                        imstring='j', row=True, mathform=True):
     r"""Return a LaTeX array given a numpy array.
@@ -141,6 +112,9 @@ def _numpyarraytolatex(a, frmt='{:6.2f}', arraytype='bmatrix', nargout=0,
       456 &  8.24
     \end{array}
     None
+    >>> a2l.to_ltx(A, frmt = '{:1.2f}', arraytype = 'coords')
+    {(1.23,23.46),(456.23,8.24)}
+    None
 
     """
     if len(a.shape) > 2:
@@ -150,6 +124,10 @@ def _numpyarraytolatex(a, frmt='{:6.2f}', arraytype='bmatrix', nargout=0,
         a = _np.array([a])
         if row is False:
             a = a.T
+
+    if arraytype == "coords":
+        coords = ['(' + ','.join([frmt.format(x) for x in r]) + ')' for r in a]
+        return '{' + ','.join(coords) + '}'
     
     arrayformat = ''
 
@@ -379,6 +357,9 @@ def to_ltx(a, frmt='{:1.2f}', arraytype=None, nargout=0,
       1.23 &  23.5\\
       456  &  8.24
     \end{array}
+    None
+    >>> a2l.to_ltx(A, frmt = '{:1.2f}', arraytype = 'coords')
+    {(1.23,23.46),(456.23,8.24)}
     None
 
     """

--- a/array_to_latex/__init__.py
+++ b/array_to_latex/__init__.py
@@ -62,6 +62,35 @@ def to_clp(a, frmt='{:1.2f}', arraytype='bmatrix', imstring='j'):
               'means to use this function')
 
 
+def to_coords(a, frmt='{:6.2f}'):
+    r"""Retrun a list of coordinates given a numpy array.
+
+    Parameters
+    ----------
+    a         : float array
+    frmt      : string
+        python 3 formatter, optional-
+        https://mkaz.tech/python-string-format.html
+    
+    Returns
+    -------
+    out: str
+        list of coordinates in the form (x1,y1),(x2,y2),...
+    
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import array_to_latex as a2l
+    >>> A = np.array([[1.23456, 23.45678],[456.23, 8.239521]])
+    >>> a2l.to_coords(A, frmt = '{:1.2f}')
+    '{(1.23,23.46),(456.23,8.24)}'
+    """
+    out = '{'
+    out += ','.join([f"({','.join([frmt.format(x) for x in r])})" for r in a])
+    out += '}'
+    return out
+
+
 def _numpyarraytolatex(a, frmt='{:6.2f}', arraytype='bmatrix', nargout=0,
                        imstring='j', row=True, mathform=True):
     r"""Return a LaTeX array given a numpy array.


### PR DESCRIPTION
Hi, I add one more format. 
If `a=[[x1,y1],[x2,y2],...]`
The new function `to_coords(a, frmt)` will output
`{(x1,y1),(x2,y2), ...}`
This format is useful for plotting data in latex.

If you feel it is useful, please merge it into your package.
